### PR TITLE
根据 data_id 匹配配置文件类型

### DIFF
--- a/src/raft/cluster/model.rs
+++ b/src/raft/cluster/model.rs
@@ -9,6 +9,7 @@ use crate::{
         db::table::{TableManagerQueryReq, TableManagerReq, TableManagerResult},
     },
 };
+use crate::config::config_type::ConfigType;
 
 pub enum RouteAddr {
     Local,
@@ -29,11 +30,12 @@ pub struct SetConfigReq {
 
 impl SetConfigReq {
     pub fn new(config_key: ConfigKey, value: Arc<String>) -> Self {
+        let data_id_clone = Arc::clone(&config_key.data_id);
         Self {
             config_key,
             value,
             op_user: None,
-            config_type: None,
+            config_type: Self::detect_config_type(data_id_clone),
             desc: None,
         }
     }
@@ -50,6 +52,18 @@ impl SetConfigReq {
             config_type: None,
             desc: None,
         }
+    }
+
+    fn detect_config_type(data_id: Arc<String>) -> Option<Arc<String>> {
+        if let Some(pos) = data_id.rfind('.') {
+            let suffix = &data_id[pos+1..];
+
+            if !suffix.is_empty() {
+                return Some(ConfigType::new_by_value(suffix).get_value());
+            }
+        }
+
+        None
     }
 }
 


### PR DESCRIPTION
``` Rust
...
impl SetConfigReq {
    pub fn new(config_key: ConfigKey, value: Arc<String>) -> Self {
        let data_id_clone = Arc::clone(&config_key.data_id);
        Self {
            config_key,
            value,
            op_user: None,
            config_type: Self::detect_config_type(data_id_clone),
            desc: None,
        }
    }

    fn detect_config_type(data_id: Arc<String>) -> Option<Arc<String>> {
        if let Some(pos) = data_id.rfind('.') {
            let suffix = &data_id[pos+1..];

            if !suffix.is_empty() {
                return Some(ConfigType::new_by_value(suffix).get_value());
            }
        }

        None
    }
...
```

导入配置文件时，根据配置文件名(data_id)后缀调用  `get_value` 映射 `config_type`,实现初始化配置格式
https://github.com/nacos-group/r-nacos/blob/03d84e963eab7603b3dd23b7849b86c501c22ae9/src/config/config_type.rs#L55-L65