### PR TITLE
feat: 增加验证码的开关

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ rnacos
 |RNACOS_ENABLE_METRICS|是否开启监控指标功能|true|true|0.5.13|
 |RNACOS_METRICS_COLLECT_INTERVAL_SECOND|监控指标采集指标间隔,单位秒,最小间隔为1秒,不能小于RNACOS_METRICS_LOG_INTERVAL_SECOND|15|5|0.5.14|
 |RNACOS_METRICS_LOG_INTERVAL_SECOND|监控指标采集打印到日志的间隔,单位秒,最小间隔为5秒|60|30|0.5.13|
-|RNACOS_CAPTCHA_SWITCH| 验证码的开关| true|true|0.5.14|
+|RNACOS_CONSOLE_ENABLE_CAPTCHA| 验证码的开关| true|true|0.5.14|
 
 启动配置方式可以参考： [运行参数说明](https://r-nacos.github.io/docs/notes/env_config/)
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ rnacos
 |RNACOS_ENABLE_METRICS|是否开启监控指标功能|true|true|0.5.13|
 |RNACOS_METRICS_COLLECT_INTERVAL_SECOND|监控指标采集指标间隔,单位秒,最小间隔为1秒,不能小于RNACOS_METRICS_LOG_INTERVAL_SECOND|15|5|0.5.14|
 |RNACOS_METRICS_LOG_INTERVAL_SECOND|监控指标采集打印到日志的间隔,单位秒,最小间隔为5秒|60|30|0.5.13|
-
+|RNACOS_CAPTCHA_SWITCH| 验证码的开关| true|true|0.5.14|
 
 启动配置方式可以参考： [运行参数说明](https://r-nacos.github.io/docs/notes/env_config/)
 

--- a/book/src/deplay_env.md
+++ b/book/src/deplay_env.md
@@ -68,6 +68,7 @@ rnacos 运行时支持的环境变量，如果不设置则按默认配置运行�
 |RNACOS_INIT_ADMIN_PASSWORD|初始化管理员密码，只在主节点第一次启动时生效|admin|rnacos123456|0.5.11|
 |RNACOS_ENABLE_METRICS|是否开启监控指标功能|true|true|0.5.13|
 |RNACOS_METRICS_LOG_INTERVAL_SECOND|监控指标采集打印到日志的间隔,单位秒,最小间隔为5秒|30|10|0.5.13|
+|RNACOS_CAPTCHA_SWITCH| 验证码的开关| true|true|0.5.14|
 
 
 注：从v0.3.0开始，默认参数启动的节点会被当做只有一个节点，当前节点是主节点的集群部署。支持其它新增的从节点加入。

--- a/book/src/deplay_env.md
+++ b/book/src/deplay_env.md
@@ -68,7 +68,7 @@ rnacos 运行时支持的环境变量，如果不设置则按默认配置运行�
 |RNACOS_INIT_ADMIN_PASSWORD|初始化管理员密码，只在主节点第一次启动时生效|admin|rnacos123456|0.5.11|
 |RNACOS_ENABLE_METRICS|是否开启监控指标功能|true|true|0.5.13|
 |RNACOS_METRICS_LOG_INTERVAL_SECOND|监控指标采集打印到日志的间隔,单位秒,最小间隔为5秒|30|10|0.5.13|
-|RNACOS_CAPTCHA_SWITCH| 验证码的开关| true|true|0.5.14|
+|RNACOS_CONSOLE_ENABLE_CAPTCHA| 验证码的开关| true|true|0.5.14|
 
 
 注：从v0.3.0开始，默认参数启动的节点会被当做只有一个节点，当前节点是主节点的集群部署。支持其它新增的从节点加入。

--- a/doc/conf/.env.example
+++ b/doc/conf/.env.example
@@ -74,5 +74,6 @@ RNACOS_METRICS_COLLECT_INTERVAL_SECOND=15
 #监控指标采集打印到日志的间隔,单位秒,最小间隔为5秒
 RNACOS_METRICS_LOG_INTERVAL_SECOND=60
 
-# 验证码的开关，在使用 openapi 进行管理获取 token 的时候需要
-RNACOS_CAPTCHA_SWITCH=true
+# 验证码的开关，在使用 openapi 进行管理获取 token 的时候需要,设置为false的时候，
+# 需要将密码base64，验证码为空后进行传递
+RNACOS_CONSOLE_ENABLE_CAPTCHA=true

--- a/doc/conf/.env.example
+++ b/doc/conf/.env.example
@@ -74,3 +74,5 @@ RNACOS_METRICS_COLLECT_INTERVAL_SECOND=15
 #监控指标采集打印到日志的间隔,单位秒,最小间隔为5秒
 RNACOS_METRICS_LOG_INTERVAL_SECOND=60
 
+# 验证码的开关，在使用 openapi 进行管理获取 token 的时候需要
+RNACOS_CAPTCHA_SWITCH=true

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -78,7 +78,7 @@ pub struct AppSysConfig {
     pub metrics_enable: bool,
     pub metrics_collect_interval_second: u64,
     pub metrics_log_interval_second: u64,
-    pub captcha_switch: bool,
+    pub console_captcha_enable: bool,
 }
 
 impl AppSysConfig {
@@ -167,7 +167,7 @@ impl AppSysConfig {
                 .unwrap_or("15".to_owned())
                 .parse()
                 .unwrap_or(15);
-        let captcha_switch = std::env::var("RNACOS_CAPTCHA_SWITCH")
+        let console_captcha_enable = std::env::var("RNACOS_CONSOLE_ENABLE_CAPTCHA")
             .unwrap_or("true".to_owned())
             .parse()
             .unwrap_or(true);
@@ -210,7 +210,7 @@ impl AppSysConfig {
             metrics_enable,
             metrics_collect_interval_second,
             metrics_log_interval_second,
-            captcha_switch,
+            console_captcha_enable,
         }
     }
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -78,6 +78,7 @@ pub struct AppSysConfig {
     pub metrics_enable: bool,
     pub metrics_collect_interval_second: u64,
     pub metrics_log_interval_second: u64,
+    pub captcha_switch: bool,
 }
 
 impl AppSysConfig {
@@ -166,6 +167,10 @@ impl AppSysConfig {
                 .unwrap_or("15".to_owned())
                 .parse()
                 .unwrap_or(15);
+        let captcha_switch = std::env::var("RNACOS_CAPTCHA_SWITCH")
+            .unwrap_or("true".to_owned())
+            .parse()
+            .unwrap_or(true);
         if metrics_collect_interval_second < 1 {
             metrics_collect_interval_second = 1;
         }
@@ -205,6 +210,7 @@ impl AppSysConfig {
             metrics_enable,
             metrics_collect_interval_second,
             metrics_log_interval_second,
+            captcha_switch,
         }
     }
 

--- a/src/console/login_api.rs
+++ b/src/console/login_api.rs
@@ -5,6 +5,7 @@ use actix_web::{
     web::{self, Data},
     HttpRequest, HttpResponse, Responder,
 };
+use actix_web::http::header;
 use captcha::filters::{Grid, Noise};
 use captcha::Captcha;
 
@@ -20,48 +21,54 @@ use crate::{
     },
     user::{UserManagerReq, UserManagerResult},
 };
-
-use super::model::login_model::LoginParam;
+use crate::common::APP_SYS_CONFIG;
+use super::model::login_model::{LoginParam, LoginToken};
 
 pub async fn login(
     request: HttpRequest,
     app: Data<Arc<AppShareData>>,
     web::Form(param): web::Form<LoginParam>,
 ) -> actix_web::Result<impl Responder> {
-    //校验验证码
-    let captcha_token = if let Some(ck) = request.cookie("captcha_token") {
-        ck.value().to_owned()
-    } else {
-        return Ok(HttpResponse::Ok().json(ApiResult::<()>::error(
-            "CAPTCHA_CHECK_ERROR".to_owned(),
-            Some("captcha token is empty".to_owned()),
-        )));
-    };
-    let captcha_code = param.captcha.to_uppercase();
-    let cache_req = CacheManagerReq::Get(CacheKey::new(
-        CacheType::String,
-        Arc::new(format!("Captcha_{}", &captcha_token)),
-    ));
-    let captcha_check_result = if let Ok(Ok(CacheManagerResult::Value(CacheValue::String(v)))) =
-        app.cache_manager.send(cache_req).await
-    {
-        &captcha_code == v.as_ref()
-    } else {
-        false
-    };
-    if !captcha_check_result {
-        return Ok(HttpResponse::Ok()
-            .cookie(
-                Cookie::build("captcha_token", "")
-                    .path("/")
-                    .http_only(true)
-                    .finish(),
-            )
-            .json(ApiResult::<()>::error(
+    let captcha_token;
+    if APP_SYS_CONFIG.captcha_switch {
+        //校验验证码
+        captcha_token = if let Some(ck) = request.cookie("captcha_token") {
+            ck.value().to_owned()
+        } else {
+            return Ok(HttpResponse::Ok().json(ApiResult::<()>::error(
                 "CAPTCHA_CHECK_ERROR".to_owned(),
-                Some("CAPTCHA_CHECK_ERROR".to_owned()),
+                Some("captcha token is empty".to_owned()),
             )));
+        };
+        let captcha_code = param.captcha.to_uppercase();
+        let cache_req = CacheManagerReq::Get(CacheKey::new(
+            CacheType::String,
+            Arc::new(format!("Captcha_{}", &captcha_token)),
+        ));
+        let captcha_check_result = if let Ok(Ok(CacheManagerResult::Value(CacheValue::String(v)))) =
+            app.cache_manager.send(cache_req).await
+        {
+            &captcha_code == v.as_ref()
+        } else {
+            false
+        };
+        if !captcha_check_result {
+            return Ok(HttpResponse::Ok()
+                .cookie(
+                    Cookie::build("captcha_token", "")
+                        .path("/")
+                        .http_only(true)
+                        .finish(),
+                )
+                .json(ApiResult::<()>::error(
+                    "CAPTCHA_CHECK_ERROR".to_owned(),
+                    Some("CAPTCHA_CHECK_ERROR".to_owned()),
+                )));
+        }
+    } else {
+        captcha_token = String::from("")
     }
+
     let limit_key = Arc::new(format!("USER_L#{}", &param.username));
     let limit_req = CacheLimiterReq::Hour {
         key: limit_key.clone(),
@@ -119,6 +126,9 @@ pub async fn login(
             let clear_limit_req =
                 CacheManagerReq::Remove(CacheKey::new(CacheType::String, limit_key));
             app.cache_manager.do_send(clear_limit_req);
+            let login_token = LoginToken {
+                token: token.to_string(),
+            };
             return Ok(HttpResponse::Ok()
                 .cookie(
                     Cookie::build("token", token.as_str())
@@ -132,7 +142,8 @@ pub async fn login(
                         .http_only(true)
                         .finish(),
                 )
-                .json(ApiResult::success(Some(valid))));
+                .insert_header(header::ContentType(mime::APPLICATION_JSON))
+                .json(ApiResult::success(Some(login_token))));
         } else {
             return Ok(HttpResponse::Ok()
                 .json(ApiResult::<()>::error("USER_CHECK_ERROR".to_owned(), None)));
@@ -143,12 +154,17 @@ pub async fn login(
 
 fn decode_password(password: &str, captcha_token: &str) -> anyhow::Result<String> {
     let password_data = crypto_utils::decode_base64(password)?;
-    let password = String::from_utf8(crypto_utils::decrypt_aes128(
-        &captcha_token[0..16],
-        &captcha_token[16..32],
-        &password_data,
-    )?)?;
-    Ok(password)
+    if captcha_token == "" {
+        let password = String::from_utf8(password_data)?;
+        Ok(password)
+    } else {
+        let password = String::from_utf8(crypto_utils::decrypt_aes128(
+            &captcha_token[0..16],
+            &captcha_token[16..32],
+            &password_data,
+        )?)?;
+        Ok(password)
+    }
 }
 
 const WIDTH: u32 = 220;

--- a/src/console/login_api.rs
+++ b/src/console/login_api.rs
@@ -30,7 +30,7 @@ pub async fn login(
     web::Form(param): web::Form<LoginParam>,
 ) -> actix_web::Result<impl Responder> {
     let captcha_token;
-    if APP_SYS_CONFIG.captcha_switch {
+    if APP_SYS_CONFIG.console_captcha_enable {
         //校验验证码
         captcha_token = if let Some(ck) = request.cookie("captcha_token") {
             ck.value().to_owned()

--- a/src/console/model/login_model.rs
+++ b/src/console/model/login_model.rs
@@ -8,3 +8,9 @@ pub struct LoginParam {
     pub password: String,
     pub captcha: String,
 }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct LoginToken {
+    pub token: String,
+}


### PR DESCRIPTION
1. 增加一个验证码的开关，默认为启用，关闭的时候可暂时用于使用 openapi 对 console 接口进行管理
2. login 接口返回的时候在响应体中的 data 字段下返回 token，方便使用接口进行对接