### PR TITLE
feat(user): prevent deletion of the last admin user

### DIFF
--- a/src/console/user_api.rs
+++ b/src/console/user_api.rs
@@ -183,6 +183,25 @@ pub async fn remove_user(
     let msg = UserManagerReq::Remove {
         username: user.username,
     };
-    app.user_manager.send(msg).await.ok();
-    Ok(HttpResponse::Ok().json(ApiResult::success(Some(true))))
+    match app.user_manager.send(msg).await {
+        Ok(r) => {
+            match r {
+                Ok(_) => {
+                    Ok(HttpResponse::Ok().json(ApiResult::success(Some(true))))
+                }
+                Err(e) => {
+                    Ok(HttpResponse::Ok().json(ApiResult::<()>::error(
+                        e.to_string(),
+                        Some(e.to_string()),
+                    )))
+                }
+            }
+        }
+        Err(e) => {
+            Ok(HttpResponse::Ok().json(ApiResult::<()>::error(
+                "SYSTEM_ERROR".to_owned(),
+                None,
+            )))
+        }
+    }
 }

--- a/src/user/permission.rs
+++ b/src/user/permission.rs
@@ -5,6 +5,7 @@
 /// 2）http请求路径，由后端拦截器控制否支持请求；
 use std::{collections::HashSet, hash::Hash, sync::Arc};
 
+
 use crate::common::constant::{EMPTY_STR, HTTP_METHOD_ALL, HTTP_METHOD_GET};
 
 pub enum Resource {
@@ -361,14 +362,27 @@ pub enum UserRole {
     OldConsole,
     None,
 }
+const MANAGER_VALUE: &'static str = "0";
+const DEVELOPER_VALUE: &'static str = "1";
+const VISITOR_VALUE: &'static str = "2";
+const NONE_VALUE: &'static str = "";
 
 impl UserRole {
     pub fn new(role_value: &str) -> Self {
         match role_value {
-            "0" => Self::Manager,
-            "1" => Self::Developer,
-            "2" => Self::Visitor,
+            MANAGER_VALUE => Self::Manager,
+            DEVELOPER_VALUE => Self::Developer,
+            VISITOR_VALUE => Self::Visitor,
             _ => Self::None,
+        }
+    }
+
+    pub fn to_role_value(&self) -> &str {
+        match self {
+            Self::Manager => MANAGER_VALUE,
+            Self::Developer => DEVELOPER_VALUE,
+            Self::Visitor => VISITOR_VALUE,
+            _ => NONE_VALUE,
         }
     }
 


### PR DESCRIPTION
feat(user): 禁止删除最后一个管理员用户

增加了检查被删除用户是否是唯一管理员的逻辑。当删除的用户为管理员时，再判断是否为唯一管理员，如果是则不允许删除。
至少保证还有一名管理员用户，避免误删除。

BREAKING CHANGE: 尝试删除最后一个管理员现在返回一个错误
并防止操作。

Refs #34