### PR TITLE
refactor: 将打印语句替换为日志记录

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -63,8 +63,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     if let Some(cmd) = cli_opt.command {
         return run_subcommand(cmd).await;
     }
-    println!("version:{}, RUST_LOG:{}", get_app_version(), &rust_log);
-    println!("data dir:{}", sys_config.local_db_dir);
+    log::info!("version:{}, RUST_LOG:{}", get_app_version(), &rust_log);
+    log::info!("data dir:{}", sys_config.local_db_dir);
     let factory_data = config_factory(sys_config.clone()).await?;
     let app_data = build_share_data(factory_data.clone())?;
     let http_addr = sys_config.get_http_addr();
@@ -125,7 +125,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     if let Some(num) = sys_config.http_workers {
         server = server.workers(num);
     }
-    println!("rnacos started");
+    log::info!("rnacos started");
     server.bind(http_addr)?.run().await?;
     Ok(())
 }


### PR DESCRIPTION
- 使用 log::info! 宏替换 println! 宏，以统一日志输出格式