### PR TITLE
feat: support extra runtime configs with env

### DIFF
--- a/deploy/k8s/helm/templates/configmap.yaml
+++ b/deploy/k8s/helm/templates/configmap.yaml
@@ -11,9 +11,9 @@ data:
     export RNACOS_RAFT_NODE_ID=$(expr 1 + $(echo $MY_POD_NAME | grep -o '[0-9]\+$'))
     export RNACOS_RAFT_JOIN_ADDR={{ include "rnacos.fullname" . }}-0.{{ include "rnacos.fullname" . }}-headless:9848
     # export RNACOS_RAFT_AUTO_INIT=true
-    export RUST_LOG={{ .Values.rancosConfig.rustLog }}
-    export RNACOS_HTTP_WORKERS={{ .Values.rancosConfig.httpWorkers }}
-    export RNACOS_CONSOLE_LOGIN_ONE_HOUR_LIMIT={{ .Values.rancosConfig.consoleLoginOneHourLimit }}
+    export RUST_LOG={{ .Values.rnacosConfig.rustLog }}
+    export RNACOS_HTTP_WORKERS={{ .Values.rnacosConfig.httpWorkers }}
+    export RNACOS_CONSOLE_LOGIN_ONE_HOUR_LIMIT={{ .Values.rnacosConfig.consoleLoginOneHourLimit }}
     echo $RNACOS_RAFT_NODE_ADDR
     echo $RNACOS_RAFT_NODE_ID
     echo $RNACOS_RAFT_JOIN_ADDR

--- a/deploy/k8s/helm/templates/statefulset.yaml
+++ b/deploy/k8s/helm/templates/statefulset.yaml
@@ -39,13 +39,11 @@ spec:
           readinessProbe:
             tcpSocket:
               port: 9848
-              service: ""
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
             tcpSocket:
               port: 9848
-              service: ""
             initialDelaySeconds: 15
             periodSeconds: 20
           env:
@@ -57,6 +55,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            {{- with .Values.extraEnvVars }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           volumeMounts:
             - name: podinfo
               mountPath: /etc/podinfo

--- a/deploy/k8s/helm/values.yaml
+++ b/deploy/k8s/helm/values.yaml
@@ -19,6 +19,8 @@ rancosConfig:
   httpWorkers: 8
   consoleLoginOneHourLimit: 5
 
+extraEnvVars: []
+
 persistence:
   size: 20Gi
   storageClass: default

--- a/deploy/k8s/helm/values.yaml
+++ b/deploy/k8s/helm/values.yaml
@@ -14,11 +14,13 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-rancosConfig:
+rnacosConfig:
   rustLog: info
   httpWorkers: 8
   consoleLoginOneHourLimit: 5
 
+# more configs from environment variables
+# https://r-nacos.github.io/docs/notes/env_config/#%E8%BF%90%E8%A1%8C%E5%8F%82%E6%95%B0%E8%AF%B4%E6%98%8E
 extraEnvVars: []
 
 persistence:


### PR DESCRIPTION
this PR made the following changes:

1. support more configs with extraEnvVars;
2. maybe fix the `rancosConfig` typo error?