### PR TITLE
feat(openapi): add 2.x open api for namespace management

### DIFF
--- a/src/console/mod.rs
+++ b/src/console/mod.rs
@@ -205,6 +205,22 @@ impl NamespaceUtils {
         }
     }
 
+    pub async fn get_namespace(
+        app_share_data: &Arc<AppShareData>,
+        namespace_id: Option<Arc<String>>,
+    ) -> anyhow::Result<NamespaceInfo> {
+        let namespace_id = namespace_id.unwrap_or_default();
+        let res = app_share_data
+            .namespace_addr
+            .send(NamespaceQueryReq::Info(namespace_id.clone()))
+            .await??;
+        if let NamespaceQueryResult::Info(info) = res {
+            Ok(info.as_ref().to_owned().into())
+        } else {
+            Err(anyhow::anyhow!("NamespaceQueryResult is error"))
+        }
+    }
+
     pub async fn add_namespace(
         app_data: &Arc<AppShareData>,
         info: NamespaceInfo,

--- a/src/openapi/v2/console/mod.rs
+++ b/src/openapi/v2/console/mod.rs
@@ -1,0 +1,1 @@
+pub mod namespace;

--- a/src/openapi/v2/console/namespace.rs
+++ b/src/openapi/v2/console/namespace.rs
@@ -1,0 +1,91 @@
+use crate::openapi::v1::console::namespace::{NamespaceVO, NamespaceParam};
+use crate::openapi::v2::model::ApiResult;
+use crate::common::string_utils::StringUtils;
+use crate::common::appdata::AppShareData;
+use crate::console::model::NamespaceInfo;
+use crate::console::NamespaceUtils;
+use crate::merge_web_param;
+use actix_web::{web, HttpResponse, Responder};
+use std::sync::Arc;
+use uuid::Uuid;
+
+pub async fn query_namespace_list(app_data: web::Data<Arc<AppShareData>>) -> impl Responder {
+    let namespaces = match NamespaceUtils::get_namespaces(&app_data).await {
+        Ok(namespaces) => namespaces,
+        Err(e) => return HttpResponse::InternalServerError().json(ApiResult::server_error(e.to_string())),
+    };
+    let list: Vec<NamespaceVO> = namespaces
+        .iter()
+        .map(|e| e.clone().into())
+        .collect();
+    HttpResponse::Ok().json(ApiResult::success(list))
+}
+
+pub async fn query_namespace(
+    web::Query(param): web::Query<NamespaceParam>,
+    payload: web::Payload,
+    app_data: web::Data<Arc<AppShareData>>,
+) -> impl Responder {
+    let param = merge_web_param!(param, payload);
+    match NamespaceUtils::get_namespace(&app_data, param.namespace_id).await {
+        Ok(namespace) => {
+            let namespace: NamespaceVO = namespace.into();
+            HttpResponse::Ok().json(ApiResult::success(namespace))
+        },
+        Err(e) => HttpResponse::InternalServerError().json(
+            ApiResult::server_error(e.to_string())
+        ),
+    }
+}
+
+pub async fn add_namespace(
+    web::Query(param): web::Query<NamespaceParam>,
+    payload: web::Payload,
+    app_data: web::Data<Arc<AppShareData>>,
+) -> impl Responder {
+    let param = merge_web_param!(param, payload);
+    let mut param: NamespaceInfo = param.into();
+    if StringUtils::is_option_empty_arc(&param.namespace_id) {
+        param.namespace_id = Some(Arc::new(Uuid::new_v4().to_string()));
+    }
+    match NamespaceUtils::add_namespace(&app_data, param).await {
+        Ok(_) => HttpResponse::Ok().json(
+            ApiResult::success(true)
+        ),
+        Err(e) => HttpResponse::InternalServerError().json(
+            ApiResult::server_error(e.to_string())
+        ),
+    }
+}
+
+pub async fn update_namespace(
+    web::Query(param): web::Query<NamespaceParam>,
+    payload: web::Payload,
+    app_data: web::Data<Arc<AppShareData>>,
+) -> impl Responder {
+    let param = merge_web_param!(param, payload);
+    match NamespaceUtils::update_namespace(&app_data, param.into()).await {
+        Ok(_) => HttpResponse::Ok().json(
+            ApiResult::success(true)
+        ),
+        Err(e) => HttpResponse::InternalServerError().json(
+            ApiResult::server_error(e.to_string())
+        ),
+    }
+}
+
+pub async fn remove_namespace(
+    web::Query(param): web::Query<NamespaceParam>,
+    payload: web::Payload,
+    app_data: web::Data<Arc<AppShareData>>,
+) -> impl Responder {
+    let param = merge_web_param!(param, payload);
+    match NamespaceUtils::remove_namespace(&app_data, param.namespace_id).await {
+        Ok(_) => HttpResponse::Ok().json(
+            ApiResult::success(true)
+        ),
+        Err(e) => HttpResponse::InternalServerError().json(
+            ApiResult::server_error(e.to_string())
+        ),
+    }
+}

--- a/src/openapi/v2/mod.rs
+++ b/src/openapi/v2/mod.rs
@@ -12,3 +12,6 @@
 // pub fn openapi_route<F>(conf: &RouteConf) -> F where F: HttpServiceFactory + 'static {
 //
 // }
+
+pub mod model;
+pub mod console;

--- a/src/openapi/v2/model.rs
+++ b/src/openapi/v2/model.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct ApiResult<T>
+where
+    T: Sized + Default
+{
+    pub code: i32,
+    pub message: String,
+    pub data: T,
+}
+
+impl<T> ApiResult<T>
+where
+    T: Sized + Default
+{
+    pub fn success(data: T) -> Self {
+        Self {
+            code: 0,
+            message: "success".into(),
+            data,
+        }
+    }
+
+    pub fn error(code: i32, message: String, data: T) -> Self {
+        Self {
+            code,
+            message,
+            data,
+        }
+    }
+
+    pub fn server_error(data: T) -> Self {
+        Self::error(30000, "server error".into(), data)
+    }
+}

--- a/src/web_config.rs
+++ b/src/web_config.rs
@@ -9,7 +9,7 @@ use crate::openapi::auth::{login_config, mock_token};
 use crate::openapi::backup::backup_config;
 use crate::openapi::health::health_config;
 use crate::openapi::metrics::metrics_config;
-use crate::openapi::{openapi_config, v1::console as nacos_console};
+use crate::openapi::{openapi_config, v1::console as nacos_console, v2::console as nacos_console_v2};
 use crate::raft::network::raft_config;
 
 /*
@@ -148,6 +148,20 @@ pub fn nacos_console_api_config(config: &mut ServiceConfig) {
                 .route(web::delete().to(nacos_console::namespace::remove_namespace)),
         ),
     );
+
+    config.service(
+        web::scope("/nacos/v2/console").service(
+            web::resource("/namespace/list")
+                .route(web::get().to(nacos_console_v2::namespace::query_namespace_list)),
+            ).service(
+            web::resource("/namespace")
+                .route(web::get().to(nacos_console_v2::namespace::query_namespace))
+                .route(web::post().to(nacos_console_v2::namespace::add_namespace))
+                .route(web::put().to(nacos_console_v2::namespace::update_namespace))
+                .route(web::delete().to(nacos_console_v2::namespace::remove_namespace)),
+            ),
+    );
+
 }
 
 /// 独立控制台服务


### PR DESCRIPTION
#149 补充了 2.x OpenAPI 命名空间部分接口，主要改动有：
- `src/web_config.rs` 加入 2.x OpenAPI 命名空间请求路径的路由。
- `src/openapi/v2/model.rs` 添加 2.x OpenAPI 统一返回体格式的模型。
- `src/console/mod.rs` 为`NamespaceUtils`增加函数`get_namespace`以支持新接口`查询具体命名空间`。
- `src/openapi/v2/console/namespace.rs` 接口函数位置。