### PR TITLE
ci: update GitHub Actions to use ubuntu-latest

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:


### PR DESCRIPTION
### Summary:
The CI failed due to the fact that Ubuntu 20.04 is no longer supported.
This PR updates the GitHub Actions workflow to use ubuntu-latest instead of ubuntu-20.04.

### Reference: 
- [GitHub Actions Issue #11101](https://github.com/actions/runner-images/issues/11101)